### PR TITLE
Clean up

### DIFF
--- a/Coefficients of a Linear Combination of Quantum States.html
+++ b/Coefficients of a Linear Combination of Quantum States.html
@@ -1,12 +1,9 @@
-<DOCTYPE! html>
+<!DOCTYPE html>
 <html>
 <head>
-	<meta charset = "utf-8">
+	<meta charset="utf-8">
 	<meta name=viewport content="width=device-width, initial-scale=1">
-	<link rel = "stylesheet" href = "docs.css">
-	<link href='https://fonts.googleapis.com/css?family=Neuton' rel='stylesheet' type='text/css'>
-	<link href='https://fonts.googleapis.com/css?family=Gentium+Basic' rel='stylesheet' type='text/css'>
-	<link href='https://fonts.googleapis.com/css?family=Playfair+Display+SC' rel='stylesheet' type='text/css'>
+	<link rel="stylesheet" href="docs.css">
 	<script type="text/javascript" async
 	  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
 	</script>
@@ -36,9 +33,9 @@
 			$$
 			\begin{align} 
 			|\Psi|^2 
-			&=|c_1\psi_1+c_2\psi_2|^2 \\
-			&= (c_1\psi_1+c_2\psi_2)(c_1^*\psi_1^*+c_2^*\psi_2^*) \\
-			&= |c_1|^2|\psi_1|^2+|c_2|^2|\psi_2|^2+c_1\psi_1 c_2^*\psi_2^*+c_1^*\psi_1^* c_2\psi_2 
+			&amp;=|c_1\psi_1+c_2\psi_2|^2 \\
+			&amp;= (c_1\psi_1+c_2\psi_2)(c_1^*\psi_1^*+c_2^*\psi_2^*) \\
+			&amp;= |c_1|^2|\psi_1|^2+|c_2|^2|\psi_2|^2+c_1\psi_1 c_2^*\psi_2^*+c_1^*\psi_1^* c_2\psi_2 
 			\end{align}
 			$$
 
@@ -51,15 +48,13 @@
 			$$
 			\begin{align}
 			\int_{-\infty}^{\infty}|\Psi|^2 \ dx
-			&= \int_{-\infty}^{\infty}|c_1|^2 |\psi_1|^2 \ dx + \int_{-\infty}^{\infty}|c_2|^2 |\psi_2|^2 \ dx + c_1 c_2^*\int_{-\infty}^{\infty} \psi_2^* \psi_1 \ dx + c_1^* c_2\int_{-\infty}^{\infty}\psi_1^* \psi_2 \ dx \\
-			&= |c_1|^2 + |c_2|^2 \\
-			&= 1
+			&amp;= \int_{-\infty}^{\infty}|c_1|^2 |\psi_1|^2 \ dx + \int_{-\infty}^{\infty}|c_2|^2 |\psi_2|^2 \ dx + c_1 c_2^*\int_{-\infty}^{\infty} \psi_2^* \psi_1 \ dx + c_1^* c_2\int_{-\infty}^{\infty}\psi_1^* \psi_2 \ dx \\
+			&amp;= |c_1|^2 + |c_2|^2 \\
+			&amp;= 1
 			\end{align}
 			$$
 
 			Thus \(|c_1|^2\) and \(|c_2|^2\) are the probabilities of finding \(\Psi\) in the state \(\psi_1\) and \(\psi_2\) respectively.
 		</p>
-
-
 </body>
-</html>      
+</html>

--- a/Coefficients of a Linear Combination of Quantum States.html
+++ b/Coefficients of a Linear Combination of Quantum States.html
@@ -24,7 +24,7 @@
 		<p>This article will show that if the quantum states of the system are <em>orthogonal</em>, \(|c_n|^2\) gives the probability of finding the system in the  state \(\psi_n(x)\).
 		</p>
 
-		<p class = "notes">
+		<p class="notes">
 			<strong>Orthogonal States</strong>&nbsp;If \(\psi_1\) and \(\psi_2\) satisfy \(\int_{-\infty}^{\infty} \psi_1^*\psi_2 \ dx=0\), these states are said to be orthogonal to each other. This is rather similar to the dot product for vectors &mdash; if \(\mathbf{a}\cdot\mathbf{b}=0\), \(\mathbf{a}\) and \(\mathbf{b}\) are orthogonal to each other, i.e. they do not 'lie' in each other.
 		</p>
 

--- a/Ehrenfest's Theorem.html
+++ b/Ehrenfest's Theorem.html
@@ -1,12 +1,9 @@
-<DOCTYPE! html>
+<!DOCTYPE html>
 <html>
 <head>
-	<meta charset = "utf-8">
+	<meta charset="utf-8">
 	<meta name=viewport content="width=device-width, initial-scale=1">
-	<link rel = "stylesheet" href = "docs.css">
-	<link href='https://fonts.googleapis.com/css?family=Neuton' rel='stylesheet' type='text/css'>
-	<link href='https://fonts.googleapis.com/css?family=Gentium+Basic' rel='stylesheet' type='text/css'>
-	<link href='https://fonts.googleapis.com/css?family=Playfair+Display+SC' rel='stylesheet' type='text/css'>
+	<link rel="stylesheet" href="docs.css">
 	<script type="text/javascript" async
 	  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
 	</script>
@@ -52,9 +49,9 @@
 			$$
 			\begin{align}
 			\frac{d\langle{x}\rangle}{dt} 
-			&= \frac{d}{dt} \int_{-\infty}^{\infty} x\psi^*\psi \ dx \\[9pt]
-			&= \int_{-\infty}^{\infty} \frac{\partial}{\partial t} (x\psi^*\psi) \ dx \\[9pt]
-			&= \int_{-\infty}^{\infty} x \left(\psi \frac{\partial \psi^*}{\partial t} + \psi^* \frac{\partial \psi}{\partial t} \right) \ dx 
+			&amp;= \frac{d}{dt} \int_{-\infty}^{\infty} x\psi^*\psi \ dx \\[9pt]
+			&amp;= \int_{-\infty}^{\infty} \frac{\partial}{\partial t} (x\psi^*\psi) \ dx \\[9pt]
+			&amp;= \int_{-\infty}^{\infty} x \left(\psi \frac{\partial \psi^*}{\partial t} + \psi^* \frac{\partial \psi}{\partial t} \right) \ dx 
 			\end{align}
 			$$
 
@@ -78,10 +75,10 @@
 			$$ 
 			\begin{align}
 			\frac{d\langle{x}\rangle}{dt} 
-			&= \frac{i\hbar}{2m} \int_{-\infty}^{\infty} x \left(\psi^* \frac{\partial^2 \psi}{\partial{x^2}} - \psi \frac{\partial^2 \psi^*}{\partial{x^2}} \right) \ dx \\[9pt]
-			&= \frac{i\hbar}{2m} \int_{-\infty}^{\infty} x \frac{\partial}{\partial x} \left(\psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x} \right) \ dx \\[9pt]
-			&= \frac{i\hbar}{2m} \left[x \left(\psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x} \right) - \int \left(\psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x} \right) \ dx \right]_{-\infty}^{\infty} \\[9pt]
-			&= -\frac{i\hbar}{2m} \int_{-\infty}^{\infty} \left( \psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x} \right) \ dx 
+			&amp;= \frac{i\hbar}{2m} \int_{-\infty}^{\infty} x \left(\psi^* \frac{\partial^2 \psi}{\partial{x^2}} - \psi \frac{\partial^2 \psi^*}{\partial{x^2}} \right) \ dx \\[9pt]
+			&amp;= \frac{i\hbar}{2m} \int_{-\infty}^{\infty} x \frac{\partial}{\partial x} \left(\psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x} \right) \ dx \\[9pt]
+			&amp;= \frac{i\hbar}{2m} \left[x \left(\psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x} \right) - \int \left(\psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x} \right) \ dx \right]_{-\infty}^{\infty} \\[9pt]
+			&amp;= -\frac{i\hbar}{2m} \int_{-\infty}^{\infty} \left( \psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x} \right) \ dx 
 			\end{align}
 			$$
 
@@ -89,9 +86,9 @@
 
 			$$
 			\begin{align}
-			& \frac{i\hbar}{2m} \left\{ \left[\psi \psi^* - \int \psi^* \frac{\partial \psi}{\partial x} \right]_{-\infty}^{\infty} - \int_{-\infty}^{\infty} \psi^* \frac{\partial \psi}{\partial x} \ dx \right\} \\[9pt]
-			&= -\frac{i\hbar}{m} \int_{-\infty}^{\infty} \psi^* \frac{\partial \psi}{\partial x} \ dx \\[9pt]
-			&= \frac{1}{m} \int_{-\infty}^{\infty} \psi^* \left(-i\hbar \frac{\partial}{\partial x} \right) \psi \ dx 
+			&amp; \frac{i\hbar}{2m} \left\{ \left[\psi \psi^* - \int \psi^* \frac{\partial \psi}{\partial x} \right]_{-\infty}^{\infty} - \int_{-\infty}^{\infty} \psi^* \frac{\partial \psi}{\partial x} \ dx \right\} \\[9pt]
+			&amp;= -\frac{i\hbar}{m} \int_{-\infty}^{\infty} \psi^* \frac{\partial \psi}{\partial x} \ dx \\[9pt]
+			&amp;= \frac{1}{m} \int_{-\infty}^{\infty} \psi^* \left(-i\hbar \frac{\partial}{\partial x} \right) \psi \ dx 
 			\end{align}
 			$$
 
@@ -120,19 +117,19 @@
 			$$
 				\begin{align} 
 				\frac{d\langle{p}\rangle}{dt} 
-				&= -i\hbar \frac{d}{dt} \int_{-\infty}^{\infty} \psi \frac{\partial \psi}{\partial x} \ dx \\[9pt]
-				&= -i\hbar \int_{-\infty}^{\infty}\frac{\partial}{\partial t}\left(\psi \frac{\partial \psi}{\partial x}\right) \ dx \\[9pt]
-				&= -i\hbar \int_{-\infty}^{\infty} \left(\frac{\partial{\psi^*}}{\partial t} \frac{\partial \psi}{\partial x} + \psi^* \frac{\partial^2 \psi}{\partial{t}\partial{x}}\right) \ dx
+				&amp;= -i\hbar \frac{d}{dt} \int_{-\infty}^{\infty} \psi \frac{\partial \psi}{\partial x} \ dx \\[9pt]
+				&amp;= -i\hbar \int_{-\infty}^{\infty}\frac{\partial}{\partial t}\left(\psi \frac{\partial \psi}{\partial x}\right) \ dx \\[9pt]
+				&amp;= -i\hbar \int_{-\infty}^{\infty} \left(\frac{\partial{\psi^*}}{\partial t} \frac{\partial \psi}{\partial x} + \psi^* \frac{\partial^2 \psi}{\partial{t}\partial{x}}\right) \ dx
 				\end{align}
 			$$
 
 			Noting that \(\frac{\partial^2 \psi}{\partial{t}\partial{x}} = \frac{\partial^2 \psi}{\partial{x}\partial{t}}\) from the <a href = "https://en.wikipedia.org/wiki/Symmetry_of_second_derivatives" target = "_blank">symmetry of second derivatives</a>, we could write
 
 			$$
-				\begin{align} &
+				\begin{align} &amp;
 				-i\hbar \int_{-\infty}^{\infty} \left(\frac{\partial{\psi^*}}{\partial t} \frac{\partial \psi}{\partial x} + \psi^* \frac{\partial^2 \psi}{\partial{t}\partial{x}}\right) \ dx \\[9pt]
-				&= -i\hbar \int_{-\infty}^{\infty} \left\{\frac{\partial{\psi^*}}{\partial t} \frac{\partial \psi}{\partial x} + \psi^* \frac{\partial}{\partial x} \left(\frac{\partial \psi}{\partial t}\right)\right\} \ dx \\[9pt]
-				&= -i\hbar \int_{-\infty}^{\infty} \left\{\frac{i\hbar}{2m} \left(\psi^* \frac{\partial^3 \psi}{\partial x^3} - \frac{\partial^2 \psi^*}{\partial x^2} \frac{\partial \psi}{\partial x}\right) - \frac{i}{\hbar} \psi \psi^* \frac{\partial V}{\partial x}\right\} \ dx \label{5} \tag{5} 
+				&amp;= -i\hbar \int_{-\infty}^{\infty} \left\{\frac{\partial{\psi^*}}{\partial t} \frac{\partial \psi}{\partial x} + \psi^* \frac{\partial}{\partial x} \left(\frac{\partial \psi}{\partial t}\right)\right\} \ dx \\[9pt]
+				&amp;= -i\hbar \int_{-\infty}^{\infty} \left\{\frac{i\hbar}{2m} \left(\psi^* \frac{\partial^3 \psi}{\partial x^3} - \frac{\partial^2 \psi^*}{\partial x^2} \frac{\partial \psi}{\partial x}\right) - \frac{i}{\hbar} \psi \psi^* \frac{\partial V}{\partial x}\right\} \ dx \label{5} \tag{5} 
 				\end{align}
 			$$
 
@@ -142,12 +139,12 @@
 			Let's evaluate the first term.
 
 			$$
-				\begin{align}&
+				\begin{align}&amp;
 				-i\hbar \int_{-\infty}^{\infty} \frac{i\hbar}{2m} \left(\psi^* \frac{\partial^3 \psi}{\partial x^3} - \frac{\partial^2 \psi^*}{\partial x^2} \frac{\partial \psi}{\partial x}\right) \ dx \\[9pt]
-				&= \frac{\hbar^2}{2m} \int_{-\infty}^{\infty} \frac{\partial^2}{\partial x^2} \left(\psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x}\right) \ dx \\[9pt]
-				&= \frac{\hbar^2}{2m} \left\{ \frac{\partial}{\partial x} \left[\psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x}\right] \right\} \Biggr\rvert_{-\infty}^{\infty} \\[9pt]
-				&= \frac{\hbar^2}{2m} \left[\frac{\partial \psi^*}{\partial x} \frac{\partial \psi}{\partial x} + \psi^* \frac{\partial^2 \psi}{\partial x^2} - \frac{\partial \psi}{\partial x} \frac{\partial \psi^*}{\partial x} - \psi \frac{\partial^2 \psi^*}{\partial x^2}\right]_{-\infty}^{\infty} \\[9pt]
-				&= 0
+				&amp;= \frac{\hbar^2}{2m} \int_{-\infty}^{\infty} \frac{\partial^2}{\partial x^2} \left(\psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x}\right) \ dx \\[9pt]
+				&amp;= \frac{\hbar^2}{2m} \left\{ \frac{\partial}{\partial x} \left[\psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x}\right] \right\} \Biggr\rvert_{-\infty}^{\infty} \\[9pt]
+				&amp;= \frac{\hbar^2}{2m} \left[\frac{\partial \psi^*}{\partial x} \frac{\partial \psi}{\partial x} + \psi^* \frac{\partial^2 \psi}{\partial x^2} - \frac{\partial \psi}{\partial x} \frac{\partial \psi^*}{\partial x} - \psi \frac{\partial^2 \psi^*}{\partial x^2}\right]_{-\infty}^{\infty} \\[9pt]
+				&amp;= 0
 				\end{align}
 			$$
 
@@ -159,9 +156,9 @@
 			$$
 				\begin{align}
 				\frac{d\langle{p}\rangle}{dt} 
-				&= -i\hbar \int_{-\infty}^{\infty} \left(-\frac{i}{\hbar} \psi \psi^* \frac{\partial V}{\partial x}\right) \ dx \\[9pt]
-				&= -\int_{-\infty}^{\infty} \psi^* \frac{\partial V}{\partial x} \psi \ dx \\[9pt] 
-				&= -\left\langle \frac{\partial V}{\partial x}\right\rangle
+				&amp;= -i\hbar \int_{-\infty}^{\infty} \left(-\frac{i}{\hbar} \psi \psi^* \frac{\partial V}{\partial x}\right) \ dx \\[9pt]
+				&amp;= -\int_{-\infty}^{\infty} \psi^* \frac{\partial V}{\partial x} \psi \ dx \\[9pt] 
+				&amp;= -\left\langle \frac{\partial V}{\partial x}\right\rangle
 				\end{align}
 			$$
 			$$
@@ -182,4 +179,3 @@
 
 </body>
 </html>
-

--- a/Ehrenfest's Theorem.html
+++ b/Ehrenfest's Theorem.html
@@ -7,7 +7,6 @@
 	<script type="text/javascript" async
 	  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
 	</script>
-	
 	<title>Ehrenfest's Theorem</title>
 </head>
 
@@ -15,7 +14,7 @@
 	<h1>Ehrenfest's Theorem</h1>
 	<h2>The Correspondence Between Quantum and Classical Mechanics</h2>
 		<p>
-			This article will show that the mean values of the 1-dimensional position \(x\), momentum \(p\) and force \(\frac{\partial{V}}{\partial{x}}\) as described by the wavefunction \(\psi\), which is a solution to the Schr&#246;dinger equation, satisfies the Newtonian laws of motion in the form 
+			This article will show that the mean values of the 1-dimensional position \(x\), momentum \(p\) and force \(\frac{\partial{V}}{\partial{x}}\) as described by the wavefunction \(\psi\), which is a solution to the Schr&#246;dinger equation, satisfies the Newtonian laws of motion in the form
 
 			$$
 			\frac{dx}{dt} = \frac{p}{m} \tag{1}
@@ -39,34 +38,34 @@
 			The mean value of \(x\) is given by
 
 			$$ 
-			\langle{x}\rangle 
-			= \int_{-\infty}^{\infty} x \lvert \psi \rvert^2 \ dx 
-			= \int_{-\infty}^{\infty} x\psi^*\psi \ dx 
+			\langle{x}\rangle
+			= \int_{-\infty}^{\infty} x \lvert \psi \rvert^2 \ dx
+			= \int_{-\infty}^{\infty} x\psi^*\psi \ dx
 			$$
 
 			taking the derivative with respect to time \(t\),
 
 			$$
 			\begin{align}
-			\frac{d\langle{x}\rangle}{dt} 
+			\frac{d\langle{x}\rangle}{dt}
 			&amp;= \frac{d}{dt} \int_{-\infty}^{\infty} x\psi^*\psi \ dx \\[9pt]
 			&amp;= \int_{-\infty}^{\infty} \frac{\partial}{\partial t} (x\psi^*\psi) \ dx \\[9pt]
-			&amp;= \int_{-\infty}^{\infty} x \left(\psi \frac{\partial \psi^*}{\partial t} + \psi^* \frac{\partial \psi}{\partial t} \right) \ dx 
+			&amp;= \int_{-\infty}^{\infty} x \left(\psi \frac{\partial \psi^*}{\partial t} + \psi^* \frac{\partial \psi}{\partial t} \right) \ dx
 			\end{align}
 			$$
 
-			\(\frac{d}{dt}\) could be brought into the integral due to the <a href = "https://en.wikipedia.org/wiki/Leibniz_integral_rule" target = "_blank">Leibniz integral rule</a>.
+			\(\frac{d}{dt}\) could be brought into the integral due to the <a href="https://en.wikipedia.org/wiki/Leibniz_integral_rule" target = "_blank">Leibniz integral rule</a>.
 		</p>
 		<p>
 			The Schr&#246;dinger equation gives, along with its complex conjugate:
 
 			$$
-			i\hbar \frac{\partial \psi}{\partial t} = 
+			i\hbar \frac{\partial \psi}{\partial t} =
 			-\frac{\hbar^2}{2m} \frac{\partial^2 \psi}{\partial x^2} + V\psi
 			$$
 
 			$$
-			-i\hbar \frac{\partial \psi^*}{\partial t} = 
+			-i\hbar \frac{\partial \psi^*}{\partial t} =
 			-\frac{\hbar^2}{2m} \frac{\partial^2 \psi^*}{\partial x^2} + V\psi^*
 			$$
 
@@ -74,11 +73,11 @@
 
 			$$ 
 			\begin{align}
-			\frac{d\langle{x}\rangle}{dt} 
+			\frac{d\langle{x}\rangle}{dt}
 			&amp;= \frac{i\hbar}{2m} \int_{-\infty}^{\infty} x \left(\psi^* \frac{\partial^2 \psi}{\partial{x^2}} - \psi \frac{\partial^2 \psi^*}{\partial{x^2}} \right) \ dx \\[9pt]
 			&amp;= \frac{i\hbar}{2m} \int_{-\infty}^{\infty} x \frac{\partial}{\partial x} \left(\psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x} \right) \ dx \\[9pt]
 			&amp;= \frac{i\hbar}{2m} \left[x \left(\psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x} \right) - \int \left(\psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x} \right) \ dx \right]_{-\infty}^{\infty} \\[9pt]
-			&amp;= -\frac{i\hbar}{2m} \int_{-\infty}^{\infty} \left( \psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x} \right) \ dx 
+			&amp;= -\frac{i\hbar}{2m} \int_{-\infty}^{\infty} \left( \psi^* \frac{\partial \psi}{\partial x} - \psi \frac{\partial \psi^*}{\partial x} \right) \ dx
 			\end{align}
 			$$
 
@@ -88,25 +87,25 @@
 			\begin{align}
 			&amp; \frac{i\hbar}{2m} \left\{ \left[\psi \psi^* - \int \psi^* \frac{\partial \psi}{\partial x} \right]_{-\infty}^{\infty} - \int_{-\infty}^{\infty} \psi^* \frac{\partial \psi}{\partial x} \ dx \right\} \\[9pt]
 			&amp;= -\frac{i\hbar}{m} \int_{-\infty}^{\infty} \psi^* \frac{\partial \psi}{\partial x} \ dx \\[9pt]
-			&amp;= \frac{1}{m} \int_{-\infty}^{\infty} \psi^* \left(-i\hbar \frac{\partial}{\partial x} \right) \psi \ dx 
+			&amp;= \frac{1}{m} \int_{-\infty}^{\infty} \psi^* \left(-i\hbar \frac{\partial}{\partial x} \right) \psi \ dx
 			\end{align}
 			$$
 
-			(Note that \(\psi \psi^*\) is zero at \(\pm \infty\)) 
+			(Note that \(\psi \psi^*\) is zero at \(\pm \infty\))
 		</p>
 		<p>
 
-			Here \(\langle{p}\rangle = \int_{-\infty}^{\infty} \psi^* \left(-i\hbar \frac{\partial}{\partial x} \right) \psi \ dx \) is the mean momentum <strong><a href = "#footnotes">[1]</strong></a> and \(\hat p = -i\hbar \frac{\partial}{\partial x}\) is the quantum mechanical momentum operator.
+			Here \(\langle{p}\rangle = \int_{-\infty}^{\infty} \psi^* \left(-i\hbar \frac{\partial}{\partial x} \right) \psi \ dx \) is the mean momentum <strong><a href="#footnotes">[1]</strong></a> and \(\hat p = -i\hbar \frac{\partial}{\partial x}\) is the quantum mechanical momentum operator.
 		</p>
 		<p>
 			Therefore, we end up with \((\ref{3})\)
 
 			$$
 			\bbox[7pt, border: 1px solid black] {
-			\frac{d \langle{x}\rangle}{dt} 
-			= \frac{1}{m} \int_{-\infty}^{\infty} \psi^* \left(-i\hbar \frac{\partial}{\partial x} \right) \psi \ dx 
-			= \frac{\langle{p}\rangle}{m} 
-			} 
+			\frac{d \langle{x}\rangle}{dt}
+			= \frac{1}{m} \int_{-\infty}^{\infty} \psi^* \left(-i\hbar \frac{\partial}{\partial x} \right) \psi \ dx
+			= \frac{\langle{p}\rangle}{m}
+			}
 			$$
 		</p>
 
@@ -115,15 +114,15 @@
 			With the result \(\langle{p}\rangle = -i\hbar \int_{-\infty}^{\infty}\psi \frac{\partial \psi}{\partial x} \ dx\), we start off by differentiating \(\langle{p}\rangle\) with respect to time,
 
 			$$
-				\begin{align} 
-				\frac{d\langle{p}\rangle}{dt} 
+				\begin{align}
+				\frac{d\langle{p}\rangle}{dt}
 				&amp;= -i\hbar \frac{d}{dt} \int_{-\infty}^{\infty} \psi \frac{\partial \psi}{\partial x} \ dx \\[9pt]
 				&amp;= -i\hbar \int_{-\infty}^{\infty}\frac{\partial}{\partial t}\left(\psi \frac{\partial \psi}{\partial x}\right) \ dx \\[9pt]
 				&amp;= -i\hbar \int_{-\infty}^{\infty} \left(\frac{\partial{\psi^*}}{\partial t} \frac{\partial \psi}{\partial x} + \psi^* \frac{\partial^2 \psi}{\partial{t}\partial{x}}\right) \ dx
 				\end{align}
 			$$
 
-			Noting that \(\frac{\partial^2 \psi}{\partial{t}\partial{x}} = \frac{\partial^2 \psi}{\partial{x}\partial{t}}\) from the <a href = "https://en.wikipedia.org/wiki/Symmetry_of_second_derivatives" target = "_blank">symmetry of second derivatives</a>, we could write
+			Noting that \(\frac{\partial^2 \psi}{\partial{t}\partial{x}} = \frac{\partial^2 \psi}{\partial{x}\partial{t}}\) from the <a href="https://en.wikipedia.org/wiki/Symmetry_of_second_derivatives" target="_blank">symmetry of second derivatives</a>, we could write
 
 			$$
 				\begin{align} &amp;
@@ -149,7 +148,7 @@
 			$$
 
 			The term collapses to zero as \(\psi, \psi^*, \frac{\partial \psi}{\partial x}, \frac{\partial \psi^*}{\partial x}\) is zero at \(\pm \infty\).
-		</p>	
+		</p>
 		<p>
 			Hence,
 
@@ -168,14 +167,14 @@
 				= -\left\langle \frac{\partial V}{\partial x}\right\rangle
 			} (\ref{4})
 			$$
-		</p>	
+		</p>
 
-	<footer id = "footnotes">
+	<footer id="footnotes">
 		<h4>Footnotes</h4>
-		<p>	
+		<p>
 			<strong>[1]</strong> The mean value of a physical variable \(R(x,p)\) over all \(x\) can be calculated with \(\langle{R}\rangle = \int_{-\infty}^{\infty} \psi^* \hat{R}(x, -i\hbar(\partial/\partial x)) \psi \ dx\), where \(\hat{R}\) is the quantum mechanical operator for \(R\). \(\hat{R}\) could be found by replacing the \(x\)s and \(p\)s in \(R(x,p)\) with their respective operators.
 		</p>
-	</footer>	
+	</footer>
 
 </body>
 </html>

--- a/Even Potential Theorem.html
+++ b/Even Potential Theorem.html
@@ -1,12 +1,9 @@
-<DOCTYPE! html>
+<!DOCTYPE html>
 <html>
 <head>
-	<meta charset = "utf-8">
+	<meta charset="utf-8">
 	<meta name=viewport content="width=device-width, initial-scale=1">
-	<link rel = "stylesheet" href = "docs.css">
-	<link href='https://fonts.googleapis.com/css?family=Neuton' rel='stylesheet' type='text/css'>
-	<link href='https://fonts.googleapis.com/css?family=Gentium+Basic' rel='stylesheet' type='text/css'>
-	<link href='https://fonts.googleapis.com/css?family=Playfair+Display+SC' rel='stylesheet' type='text/css'>
+	<link rel="stylesheet" href="docs.css">
 	<script type="text/javascript" async
 	  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
 	</script>
@@ -62,5 +59,3 @@
 	
 </body>
 </html>
-	
-

--- a/Lagrange Multipliers.html
+++ b/Lagrange Multipliers.html
@@ -13,20 +13,20 @@
 <body>
 	<h1>Lagrange Multipliers</h1>
 		<p>
-			The Lagrange method is a tool used to find the coordinates of the maximums or minimums of a multivariable function subject to constraints. It looks for the critical points (or stationary points) of a function but <strong>does not tell you if they are maxima or minima</strong>. The extremums could only be determined by testing the coordinates found.  
+			The Lagrange method is a tool used to find the coordinates of the maximums or minimums of a multivariable function subject to constraints. It looks for the critical points (or stationary points) of a function but <strong>does not tell you if they are maxima or minima</strong>. The extremums could only be determined by testing the coordinates found.
 		</p>
 
 	<h2>Lagrange Multipliers with One Constraint</h2>
-		<p class = "notes">
-			<strong>Note:</strong> The Lagrange method applies to any \(nth\)-dimensional function, but for simplicity I'll just illustrate the method with three variables. See the footnotes for more detail <a href = "#footnotes"><strong>[1]</strong></a>.
+		<p class="notes">
+			<strong>Note:</strong> The Lagrange method applies to any \(nth\)-dimensional function, but for simplicity I'll just illustrate the method with three variables. See the footnotes for more detail <a href="#footnotes"><strong>[1]</strong></a>.
 		</p>
 
 		<p>
-			Given a function \(f(x,y,z)\) subject to a constraint \(g(x,y,z) = k\) where \(k\) is some constant, the stationary points satisfy 
+			Given a function \(f(x,y,z)\) subject to a constraint \(g(x,y,z) = k\) where \(k\) is some constant, the stationary points satisfy
 
 			$$\nabla f(x,y,z) = \lambda \nabla g(x,y,z)$$
 
-			where \(\lambda\) is some constant known as the <strong>Lagrange multiplier</strong> and \(\nabla f(x,y,z)\) and \(\nabla g(x,y,z)\) are the gradients of \(f\) and \(g\) respectively. 
+			where \(\lambda\) is some constant known as the <strong>Lagrange multiplier</strong> and \(\nabla f(x,y,z)\) and \(\nabla g(x,y,z)\) are the gradients of \(f\) and \(g\) respectively.
 		</p>
 
 		<p>
@@ -52,7 +52,7 @@
 
 	<h2>Derivation</h2>
 		<p>
-			As the variables of \(f(x,y,z)\) must satisfy \(g(x,y,z)\), we could say that \(f\) only moves in directions encompassed by \(g\). The rate of change of a critical point of \(f\) subject to \(g\) would be equal to \(0\) along all of these allowed directions. 
+			As the variables of \(f(x,y,z)\) must satisfy \(g(x,y,z)\), we could say that \(f\) only moves in directions encompassed by \(g\). The rate of change of a critical point of \(f\) subject to \(g\) would be equal to \(0\) along all of these allowed directions.
 		</p>
 
 		<p>
@@ -69,7 +69,7 @@
 		</p>
 
 		<p>
-			We end up with 
+			We end up with
 
 			$$\nabla f(x,y,z) = \lambda_1 \nabla g_1(x,y,z)$$
 			$$\nabla f(x,y,z) = \lambda_2 \nabla g_2(x,y,z)$$
@@ -91,12 +91,11 @@
 			$$\nabla f(x,y,z) = \sum^n_{i=1} \mu_i \nabla g_i(x,y,z)$$
 		</p>
 
-	<footer id = "footnotes">
+	<footer id="footnotes">
 		<h4>Footnotes</h4>
 		<p>
 			<strong>[1]</strong> With \(n\) variables, simply replace \(x,y,z\) in the equations above with \(x_1,x_2 \dots x_n\).
 		</p>
 	</footer>
-
 </body>
 </html>

--- a/Lagrange Multipliers.html
+++ b/Lagrange Multipliers.html
@@ -1,105 +1,102 @@
-	<DOCTYPE! html>
-	<html lang = "en">
-	<head>
-		<meta charset = "utf-8">
-		<meta name=viewport content="width=device-width, initial-scale=1">
-		<link rel = "stylesheet" href = "docs.css">
-		<link href='https://fonts.googleapis.com/css?family=Neuton' rel='stylesheet' type='text/css'>
-		<link href='https://fonts.googleapis.com/css?family=Gentium+Basic' rel='stylesheet' type='text/css'>
-		<link href='https://fonts.googleapis.com/css?family=Playfair+Display+SC' rel='stylesheet' type='text/css'>
-		<script type="text/javascript" async
-	  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
-		</script>
-		<title>Lagrange Multipliers</title>
-	</head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name=viewport content="width=device-width, initial-scale=1">
+	<link rel="stylesheet" href="docs.css">
+	<script type="text/javascript" async
+	src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+	</script>
+	<title>Lagrange Multipliers</title>
+</head>
 
-	<body>
-		<h1>Lagrange Multipliers</h1>
-			<p>
-				The Lagrange method is a tool used to find the coordinates of the maximums or minimums of a multivariable function subject to constraints. It looks for the critical points (or stationary points) of a function but <strong>does not tell you if they are maxima or minima</strong>. The extremums could only be determined by testing the coordinates found.  
-			</p>
+<body>
+	<h1>Lagrange Multipliers</h1>
+		<p>
+			The Lagrange method is a tool used to find the coordinates of the maximums or minimums of a multivariable function subject to constraints. It looks for the critical points (or stationary points) of a function but <strong>does not tell you if they are maxima or minima</strong>. The extremums could only be determined by testing the coordinates found.  
+		</p>
 
-		<h2>Lagrange Multipliers with One Constraint</h2>
-			<p class = "notes">
-				<strong>Note:</strong> The Lagrange method applies to any \(nth\)-dimensional function, but for simplicity I'll just illustrate the method with three variables. See the footnotes for more detail <a href = "#footnotes"><strong>[1]</strong></a>.
-			</p>
+	<h2>Lagrange Multipliers with One Constraint</h2>
+		<p class = "notes">
+			<strong>Note:</strong> The Lagrange method applies to any \(nth\)-dimensional function, but for simplicity I'll just illustrate the method with three variables. See the footnotes for more detail <a href = "#footnotes"><strong>[1]</strong></a>.
+		</p>
 
-			<p>
-				Given a function \(f(x,y,z)\) subject to a constraint \(g(x,y,z) = k\) where \(k\) is some constant, the stationary points satisfy 
+		<p>
+			Given a function \(f(x,y,z)\) subject to a constraint \(g(x,y,z) = k\) where \(k\) is some constant, the stationary points satisfy 
 
-				$$\nabla f(x,y,z) = \lambda \nabla g(x,y,z)$$
+			$$\nabla f(x,y,z) = \lambda \nabla g(x,y,z)$$
 
-				where \(\lambda\) is some constant known as the <strong>Lagrange multiplier</strong> and \(\nabla f(x,y,z)\) and \(\nabla g(x,y,z)\) are the gradients of \(f\) and \(g\) respectively. 
-			</p>
+			where \(\lambda\) is some constant known as the <strong>Lagrange multiplier</strong> and \(\nabla f(x,y,z)\) and \(\nabla g(x,y,z)\) are the gradients of \(f\) and \(g\) respectively. 
+		</p>
 
-			<p>
-				The constraint is an equation showing the relation between \(x,y\) and \(z\) in \(f\), in other words, the variables are not independent of each other. Graphically, we could visualize the relationship between \(f\) and \(g\) as their point(s) of intersection.
-			</p>
+		<p>
+			The constraint is an equation showing the relation between \(x,y\) and \(z\) in \(f\), in other words, the variables are not independent of each other. Graphically, we could visualize the relationship between \(f\) and \(g\) as their point(s) of intersection.
+		</p>
 
-			<p>
-				Writing it out in full, this means
+		<p>
+			Writing it out in full, this means
 
-				$${\partial f \over \partial x} = \lambda{\partial g \over \partial x}$$
+			$${\partial f \over \partial x} = \lambda{\partial g \over \partial x}$$
 
-				$${\partial f \over \partial y} = \lambda{\partial g \over \partial y}$$
+			$${\partial f \over \partial y} = \lambda{\partial g \over \partial y}$$
 
-				$${\partial f \over \partial z} = \lambda{\partial g \over \partial z}$$
+			$${\partial f \over \partial z} = \lambda{\partial g \over \partial z}$$
 
-				with \(g(x,y,z) = k\).
+			with \(g(x,y,z) = k\).
 
-			</p>
+		</p>
 
-			<p>
-				We now have four unknowns (\(\lambda , x,y,z\)) in four equations which could now be solved.
-			</p>
+		<p>
+			We now have four unknowns (\(\lambda , x,y,z\)) in four equations which could now be solved.
+		</p>
 
-		<h2>Derivation</h2>
-			<p>
-				As the variables of \(f(x,y,z)\) must satisfy \(g(x,y,z)\), we could say that \(f\) only moves in directions encompassed by \(g\). The rate of change of a critical point of \(f\) subject to \(g\) would be equal to \(0\) along all of these allowed directions. 
-			</p>
+	<h2>Derivation</h2>
+		<p>
+			As the variables of \(f(x,y,z)\) must satisfy \(g(x,y,z)\), we could say that \(f\) only moves in directions encompassed by \(g\). The rate of change of a critical point of \(f\) subject to \(g\) would be equal to \(0\) along all of these allowed directions. 
+		</p>
 
-			<p>
-				Let \(\hat u\) be a unit vector in the direction of the tangent to \(g(x,y,z)\), that is, in a direction of \(g\). Then the directional derivative \(D_u f = 0\) at a critical point \((x_0, y_0, z_0)\), i.e. \(\nabla f \cdot \hat u = 0\), which means \(f\) is orthogonal to \(\hat u\), and therefore is orthogonal to \(g\). What other quantity that we know of that is also orthogonal to \(g\ \)? \(\nabla g(x,y,z)\)! <strong>\(\mathbf{\nabla f(x,y,z)}\) must be parallel to \(\mathbf{\nabla g(x,y,z)}\) at \(\mathbf{(x_0,y_0,z_0)}\)</strong>. Hence we could formulate:
+		<p>
+			Let \(\hat u\) be a unit vector in the direction of the tangent to \(g(x,y,z)\), that is, in a direction of \(g\). Then the directional derivative \(D_u f = 0\) at a critical point \((x_0, y_0, z_0)\), i.e. \(\nabla f \cdot \hat u = 0\), which means \(f\) is orthogonal to \(\hat u\), and therefore is orthogonal to \(g\). What other quantity that we know of that is also orthogonal to \(g\ \)? \(\nabla g(x,y,z)\)! <strong>\(\mathbf{\nabla f(x,y,z)}\) must be parallel to \(\mathbf{\nabla g(x,y,z)}\) at \(\mathbf{(x_0,y_0,z_0)}\)</strong>. Hence we could formulate:
 
-				$$\nabla f(x,y,z) = \lambda \nabla g(x,y,z)$$
+			$$\nabla f(x,y,z) = \lambda \nabla g(x,y,z)$$
 
-				The constant \(\lambda\) is present as \(\nabla f(x_0,y_0,z_0)\) does not necessarily have the same magnitude as \(\nabla g(x_0,y_0,z_0)\).
-			</p>
+			The constant \(\lambda\) is present as \(\nabla f(x_0,y_0,z_0)\) does not necessarily have the same magnitude as \(\nabla g(x_0,y_0,z_0)\).
+		</p>
 
-		<h2>Lagrange Multipliers with Multiple Constraints</h2>
-			<p>
-				Using the same argument as above, given \(n\) constraints \(g_i(x,y,z) = k_i\) where \(i = 1,2 \dots n\), \(f(x,y,z)\) could only move along the directions provided by the constraints. The directional derivatives of \(f\) in these directions must all equal to \(0\) for a critical point \((x_0,y_0,z_0)\), i.e. \(D_{u_i} f = 0\) in the unit vectors \(\hat u_i\) tangent to \(g_i\) are equal to \(0\). Therefore, \(\nabla f(x,y,z)\) is parallel to all \(\nabla g_i(x,y,z)\).
-			</p>
+	<h2>Lagrange Multipliers with Multiple Constraints</h2>
+		<p>
+			Using the same argument as above, given \(n\) constraints \(g_i(x,y,z) = k_i\) where \(i = 1,2 \dots n\), \(f(x,y,z)\) could only move along the directions provided by the constraints. The directional derivatives of \(f\) in these directions must all equal to \(0\) for a critical point \((x_0,y_0,z_0)\), i.e. \(D_{u_i} f = 0\) in the unit vectors \(\hat u_i\) tangent to \(g_i\) are equal to \(0\). Therefore, \(\nabla f(x,y,z)\) is parallel to all \(\nabla g_i(x,y,z)\).
+		</p>
 
-			<p>
-				We end up with 
+		<p>
+			We end up with 
 
-				$$\nabla f(x,y,z) = \lambda_1 \nabla g_1(x,y,z)$$
-				$$\nabla f(x,y,z) = \lambda_2 \nabla g_2(x,y,z)$$
-				$$\vdots$$
-				$$\nabla f(x,y,z) = \lambda_n \nabla g_n(x,y,z)$$
-			</p>
+			$$\nabla f(x,y,z) = \lambda_1 \nabla g_1(x,y,z)$$
+			$$\nabla f(x,y,z) = \lambda_2 \nabla g_2(x,y,z)$$
+			$$\vdots$$
+			$$\nabla f(x,y,z) = \lambda_n \nabla g_n(x,y,z)$$
+		</p>
 
-			<p>
-				If we add these equations together,
+		<p>
+			If we add these equations together,
 
-				$$n \nabla f(x,y,z) = \lambda_1 \nabla g_1(x,y,z) +\dots+ \lambda_n \nabla g_n(x,y,z)$$
+			$$n \nabla f(x,y,z) = \lambda_1 \nabla g_1(x,y,z) +\dots+ \lambda_n \nabla g_n(x,y,z)$$
 
-				Dividing both sides by \(n\),
+			Dividing both sides by \(n\),
 
-				$$\nabla f(x,y,z) = \frac 1n [\lambda_1 g_1(x,y,z) +\dots+ \lambda_n g_n(x,y,z)]$$
+			$$\nabla f(x,y,z) = \frac 1n [\lambda_1 g_1(x,y,z) +\dots+ \lambda_n g_n(x,y,z)]$$
 
-				As \(\lambda_i\) divided by \(n\) is just another constant, we can write:
+			As \(\lambda_i\) divided by \(n\) is just another constant, we can write:
 
-				$$\nabla f(x,y,z) = \sum^n_{i=1} \mu_i \nabla g_i(x,y,z)$$
-			</p>
+			$$\nabla f(x,y,z) = \sum^n_{i=1} \mu_i \nabla g_i(x,y,z)$$
+		</p>
 
-		<footer id = "footnotes">
-			<h4>Footnotes</h4>
-			<p>
-				<strong>[1]</strong> With \(n\) variables, simply replace \(x,y,z\) in the equations above with \(x_1,x_2 \dots x_n\).
-			</p>
-		</footer>
+	<footer id = "footnotes">
+		<h4>Footnotes</h4>
+		<p>
+			<strong>[1]</strong> With \(n\) variables, simply replace \(x,y,z\) in the equations above with \(x_1,x_2 \dots x_n\).
+		</p>
+	</footer>
 
-	</body>
-	</html>
+</body>
+</html>

--- a/docs.css
+++ b/docs.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css?family=Gentium+Basic|Neuton|Playfair+Display');
+
 body
 {
 	font-family: "Neuton", "Gentium Basic", serif;
@@ -26,14 +28,9 @@ footer
 	font-size: 0.9em;
 }
 
-a:link
+a
 {
 	color: black;
-}
-
-a:visited
-{
-	color:black;
 }
 
 .notes
@@ -48,6 +45,3 @@ a:visited
 {
 	font-family: "Playfair Display SC", "Neuton", serif;
 }
-
-/*Mobile Devices*/
-

--- a/index.html
+++ b/index.html
@@ -1,15 +1,11 @@
-<DOCTYPE! html>
-<html lang = "en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
-	<meta charset = "utf-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<link rel = "stylesheet" href = "docs.css" type = "text/css">
-	<link href='https://fonts.googleapis.com/css?family=Neuton' rel='stylesheet' type='text/css'>
-	<link href='https://fonts.googleapis.com/css?family=Gentium+Basic' rel='stylesheet' type='text/css'>
-	<link href='https://fonts.googleapis.com/css?family=Playfair+Display+SC' rel='stylesheet' type='text/css'>
+	<link rel="stylesheet" href="docs.css" type="text/css">
 	<title>Schr&#246;dinger's Sigh</title>
 </head>
-
 <body>
 	<h1>Shr&#246;dinger's Sigh</h1>
 		<p>
@@ -24,14 +20,12 @@
 			<em>Irrationally enjoys pie.</em>
 		</p>
 
-	<h2 id = "special">Index</h2>
+	<h2 id="special">Index</h2>
 	<ul>
-		<li><a href = "Coefficients of a Linear Combination of Quantum States.html">Coefficients of a Linear Combination of Quantum States (29 September 2016)</a></li>
-		<li><a href = "Ehrenfest's Theorem.html">Ehrenfest's Theorem (19 August 2016)</a></li>
-		<li><a href = "Even Potential Theorem.html">The Even Potential Theorem (18 August 2016)</a></li>
-		<li><a href = "Lagrange Multipliers.html">Lagrange Multipliers (20 July 2016)</a></li>
+		<li><a href="Coefficients of a Linear Combination of Quantum States.html">Coefficients of a Linear Combination of Quantum States (29 September 2016)</a></li>
+		<li><a href="Ehrenfest's Theorem.html">Ehrenfest's Theorem (19 August 2016)</a></li>
+		<li><a href="Even Potential Theorem.html">The Even Potential Theorem (18 August 2016)</a></li>
+		<li><a href="Lagrange Multipliers.html">Lagrange Multipliers (20 July 2016)</a></li>
 	</ul>
-
 </body>
 </html>
-


### PR DESCRIPTION
### Changes

 - Trims trailing tabs and spaces.
 - Removes spaces between attributes: `<tag attr = "value">` => `<tag attr="value">`
 - `doc.css` now loads with the fonts instead of needing to manually import the fonts on each page. I think this improves responsiveness; AFAIK `@imports` in CSS are done asynchronously (they do not stop the page from being drawn).
    - also this makes maintenance better if you want to change the fonts in the future, simply change them in one file and all your pages will have the new fonts.
 - **Should not make any changes to the overall look.**

### Notes

 - I believe you don't have to use `&#246;` in place of `ö` if you already have a `<meta charset="utf8"/>`.

To pull the changes to your local copy (assuming you didn't change any files):

```
$ git pull
```